### PR TITLE
Rewrite parser for iv-org/documentation#74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ WORKDIR /app
 COPY ./shard.yml ./shard.yml
 RUN shards install
 COPY ./src/ ./src/
-RUN crystal build ./src/instances.cr --release
+RUN crystal build ./src/instances.cr -s -p -t
 
 FROM alpine:latest
-RUN apk add --no-cache gc pcre libgcc
+RUN apk add --no-cache gc pcre libgcc yaml
 WORKDIR /app
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
 COPY ./assets/ ./assets/
+COPY ./config.yml ./config.yml
 COPY --from=builder /app/instances .
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./shard.yml ./shard.yml
 RUN shards install
 COPY ./src/ ./src/
-RUN crystal build ./src/instances.cr -s -p -t
+RUN crystal build ./src/instances.cr --release
 
 FROM alpine:latest
 RUN apk add --no-cache gc pcre libgcc yaml

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,9 @@
+# Uses the system's CURL binary to do so.
+fetch_onion_instance_stats: true
+
+# TOR's Sock proxy address that CURL uses to connect to hidden services
+tor_sock_proxy_address: "127.0.0.1"
+tor_sock_proxy_port: 9050
+
+# Minutes before refreshing the instance stats
+minutes_between_refresh: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '3'
 services:
+  tor-socks-proxy:
+    container_name: tor-socks-proxy
+    image: peterdavehello/tor-socks-proxy:latest
+    ports:
+      - "127.0.0.1:8853:53/udp"
+      - "127.0.0.1:9150:9150/tcp"
+    restart: unless-stopped
+
   instances:
     build: .
     restart: unless-stopped

--- a/src/fetch.cr
+++ b/src/fetch.cr
@@ -3,7 +3,7 @@ def fetch_country(md)
   flag = md["flag"]?
   country_name = md["country_name"]?
 
-  return {flag: flag, region: region, name: country_name}
+  return flag, region, country_name
 end
 
 def fetch_notes(md)
@@ -19,7 +19,7 @@ def prepare_http_instance(md, instances, monitors)
   uri = URI.parse(md["uri"])
   host = md["host"]
 
-  country = fetch_country(md)
+  flag, region, country_name = fetch_country(md)
 
   status_url = md["status_url"]?
 
@@ -44,7 +44,7 @@ def prepare_http_instance(md, instances, monitors)
   end
 
   monitor = monitors.try &.select { |monitor| monitor["name"].try &.as_s == host }[0]?
-  return {country: country, stats: stats, type: "https", uri: uri.to_s, status_url: status_url,
+  return {flag: flag, region: region, country_name: country_name, stats: stats, type: "https", uri: uri.to_s, status_url: status_url,
           privacy_policy: privacy_policy, ddos_protection: ddos_protection,
           owner: owner, notes: notes, monitor: monitor || instances[host]?.try &.[:monitor]?}
 end
@@ -54,7 +54,7 @@ def prepare_onion_instance(md, instances)
   host = md["host"]
 
   clearnet_url = md["clearnet_url"]
-  country = fetch_country(md)
+  flag, region, country_name = fetch_country(md)
   privacy_policy = md["privacy_policy"]?
   owner = {name: md["owner"].strip("@"), url: md["owner_url"]}
   notes = fetch_notes(md)
@@ -76,7 +76,7 @@ def prepare_onion_instance(md, instances)
     stats = nil
   end
 
-  return {country: country, stats: stats, type: "onion", uri: uri.to_s, clearnet_url: clearnet_url,
+  return {flag: flag, region: region, country_name: country_name, stats: stats, type: "onion", uri: uri.to_s, clearnet_url: clearnet_url,
           privacy_policy: privacy_policy, owner: owner, notes: notes,
           monitor: nil}
 end

--- a/src/fetch.cr
+++ b/src/fetch.cr
@@ -1,0 +1,118 @@
+def fetch_country(md)
+  region = md["flag"]?.try { |region| region.codepoints.map { |codepoint| (codepoint - 0x1f1a5).chr }.join("") }
+  flag = md["flag"]?
+  country_name = md["country_name"]?
+
+  return {flag: flag, region: region, name: country_name}
+end
+
+def fetch_notes(md)
+  notes = md["notes"].strip("|")
+  if notes.empty?
+    notes = nil
+  end
+
+  return notes
+end
+
+def prepare_http_instance(md, instances, monitors)
+  uri = URI.parse(md["uri"])
+  host = md["host"]
+
+  country = fetch_country(md)
+
+  status_url = md["status_url"]?
+
+  privacy_policy = md["privacy_policy"]?
+
+  ddos_protection = md["ddos_protection"].strip
+  if ddos_protection == "None"
+    ddos_protection = nil
+  end
+
+  owner = {name: md["owner"].strip("@"), url: md["owner_url"]}
+  notes = fetch_notes(md)
+
+  client = HTTP::Client.new(uri)
+  client.connect_timeout = 5.seconds
+  client.read_timeout = 5.seconds
+
+  begin
+    stats = JSON.parse(client.get("/api/v1/stats").body)
+  rescue ex
+    stats = nil
+  end
+
+  monitor = monitors.try &.select { |monitor| monitor["name"].try &.as_s == host }[0]?
+  return {country: country, stats: stats, type: "https", uri: uri.to_s, status_url: status_url,
+          privacy_policy: privacy_policy, ddos_protection: ddos_protection,
+          owner: owner, notes: notes, monitor: monitor || instances[host]?.try &.[:monitor]?}
+end
+
+def prepare_onion_instance(md, instances)
+  uri = URI.parse(md["uri"])
+  host = md["host"]
+
+  clearnet_url = md["clearnet_url"]
+  country = fetch_country(md)
+  privacy_policy = md["privacy_policy"]?
+  owner = {name: md["owner"].strip("@"), url: md["owner_url"]}
+  notes = fetch_notes(md)
+
+  if CONFIG["fetch_onion_instance_stats"]?
+    begin
+      args = Process.parse_arguments("--socks5-hostname '#{CONFIG["tor_sock_proxy_address"]}:#{CONFIG["tor_sock_proxy_port"]}' 'http://#{uri.host}/api/v1/stats'")
+      response = nil
+      Process.run("curl", args: args) do |result|
+        data = result.output.read_line
+        response = JSON.parse(data)
+      end
+
+      stats = response
+    rescue ex
+      stats = nil
+    end
+  else
+    stats = nil
+  end
+
+  return {country: country, stats: stats, type: "onion", uri: uri.to_s, clearnet_url: clearnet_url,
+          privacy_policy: privacy_policy, owner: owner, notes: notes,
+          monitor: nil}
+end
+
+def get_clearnet_instances(body, instances, monitors)
+  # Crystal currently lacks a markdown parser that supports tables. So...
+  clear_net_regexes = [
+    /\[(?<host>[^ \]]+)\]\((?<uri>[^\)]+)\)/,                   # Address column
+    /(?<flag>[\x{1f100}-\x{1f1ff}]{2}) (?<country_name>[^ ]+)/, # Country column
+    /((\[[^\]]+\]\(.*\){1}\])\((?<status_url>.*)\)|(None))/,    # Status column
+    /((\[[^ \]]+\]\((?<privacy_policy>[^\)]+)\))|(None))/,      # privacy policy column
+    /(?<ddos_protection>.*)/,                                   # DDOS protection column
+    /\[(?<owner>[^ \]]+)\]\((?<owner_url>[^\)]+)\)/,            # Owner column
+    /(?<notes>.*)/,                                             # Note column
+  ]
+
+  body.scan(/#{clear_net_regexes.join(/ +\| +/)}/mx).each do |md|
+    host = md["host"]
+    instances[host] = prepare_http_instance(md, instances, monitors)
+  end
+end
+
+def get_onion_instances(body, instances)
+  # Crystal currently lacks a markdown parser that supports tables. So...
+  clear_net_regexes = [
+    /\[(?<host>[^ \]]+)\]\((?<uri>[^\)]+)\)/,                   # Address column
+    /(?<flag>[\x{1f100}-\x{1f1ff}]{2}) (?<country_name>[^ ]+)/, # Country column
+    /\[(?<clearnet_host>[^ \]]+)\]\((?<clearnet_url>[^\)]+)\)/, # Clearnet instance column
+    /((\[[^ \]]+\]\((?<privacy_policy>[^\)]+)\))|(None))/,      # privacy policy column
+    /\[(?<owner>[^ \]]+)\]\((?<owner_url>[^\)]+)\)/,            # Owner column
+    /(?<notes>.*)/,                                             # Notes column
+  ]
+
+  body.scan(/#{clear_net_regexes.join(/ +\| +/)}/mx).each do |md|
+    host = md["host"]
+    instances[host] = prepare_onion_instance(md, instances)
+  end
+
+end

--- a/src/fetch.cr
+++ b/src/fetch.cr
@@ -114,5 +114,4 @@ def get_onion_instances(body, instances)
     host = md["host"]
     instances[host] = prepare_onion_instance(md, instances)
   end
-
 end

--- a/src/helpers/helpers.cr
+++ b/src/helpers/helpers.cr
@@ -1,7 +1,6 @@
 require "yaml"
 
-def load_config()
+def load_config
   config = YAML.parse(File.read("config.yml"))
   return config
 end
-

--- a/src/helpers/helpers.cr
+++ b/src/helpers/helpers.cr
@@ -1,0 +1,7 @@
+require "yaml"
+
+def load_config()
+  config = YAML.parse(File.read("config.yml"))
+  return config
+end
+

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -30,9 +30,8 @@ macro rendered(filename)
 end
 
 alias Owner = NamedTuple(name: String, url: String)
-alias Country = NamedTuple(flag: String?, region: String?, name: String?)
-alias ClearNetInstance = NamedTuple(country: Country, stats: JSON::Any?, type: String, uri: String, status_url: String?, privacy_policy: String?, ddos_protection: String?, owner: Owner, notes: String?, monitor: JSON::Any?)
-alias OnionInstance = NamedTuple(country: Country, stats: JSON::Any?, type: String, uri: String, clearnet_url: String?, privacy_policy: String?, owner: Owner, notes: String?, monitor: JSON::Any?)
+alias ClearNetInstance = NamedTuple(flag: String?, region: String?, country_name: String?, stats: JSON::Any?, type: String, uri: String, status_url: String?, privacy_policy: String?, ddos_protection: String?, owner: Owner, notes: String?, monitor: JSON::Any?)
+alias OnionInstance = NamedTuple(flag: String?, region: String?, country_name: String?, stats: JSON::Any?, type: String, uri: String, clearnet_url: String?, privacy_policy: String?, owner: Owner, notes: String?, monitor: JSON::Any?)
 
 INSTANCES = {} of String => ClearNetInstance | OnionInstance
 
@@ -119,7 +118,7 @@ end
 
 SORT_PROCS = {
   "health"   => ->(name : String, instance : ClearNetInstance | OnionInstance) { -(instance[:monitor]?.try &.["30dRatio"]["ratio"].as_s.to_f || 0.0) },
-  "location" => ->(name : String, instance : ClearNetInstance | OnionInstance) { instance[:country][:region]? || "ZZ" },
+  "location" => ->(name : String, instance : ClearNetInstance | OnionInstance) { instance[:region]? || "ZZ" },
   "name"     => ->(name : String, instance : ClearNetInstance | OnionInstance) { name },
   "signup"   => ->(name : String, instance : ClearNetInstance | OnionInstance) { instance[:stats]?.try &.["openRegistrations"]?.try { |bool| bool.as_bool ? 0 : 1 } || 2 },
   "type"     => ->(name : String, instance : ClearNetInstance | OnionInstance) { instance[:type] },

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -18,6 +18,10 @@ require "http/client"
 require "kemal"
 require "uri"
 
+require "./helpers/*"
+
+CONFIG = load_config()
+
 Kemal::CLI.new ARGV
 
 macro rendered(filename)
@@ -68,6 +72,23 @@ spawn do
 
       case type = host.split(".")[-1]
       when "onion"
+        type = "onion"
+
+        if CONFIG["fetch_onion_instance_stats"]?
+          begin
+            args = Process.parse_arguments("--socks5-hostname '#{CONFIG["tor_sock_proxy_address"]}:#{CONFIG["tor_sock_proxy_port"]}' 'http://#{uri.host}/api/v1/stats'")
+            response = nil
+            Process.run("curl", args: args) do |result|
+              data = result.output.read_line
+              response = JSON.parse(data)
+            end
+
+            stats = response
+
+          rescue ex
+            stats = nil
+          end
+        end
       when "i2p"
       else
         type = uri.scheme.not_nil!
@@ -88,7 +109,7 @@ spawn do
     INSTANCES.clear
     INSTANCES.merge! instances
 
-    sleep 5.minutes
+    sleep CONFIG["minutes_between_refresh"].as_i.minutes
   end
 end
 

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -84,7 +84,6 @@ spawn do
             end
 
             stats = response
-
           rescue ex
             stats = nil
           end

--- a/src/instances/views/index.ecr
+++ b/src/instances/views/index.ecr
@@ -118,7 +118,7 @@
               <td><%= instance[:type] %></td>
               <td><%= instance[:stats]?.try &.["usage"]?.try &.["users"]["total"] || "-" %></td>
               <td><%= instance[:stats]?.try &.["openRegistrations"]?.try { |bool| bool.as_bool ? "✔" : "❌" } || "-" %></td>
-              <td><%= instance[:country]? ? "#{instance[:country][:flag]} #{instance[:country][:name]}" : "-" %></td>
+              <td><%= instance[:flag]? ? "#{instance[:flag]} #{instance[:region]}" : "-" %></td>
               <td><%= instance[:monitor]?.try &.["30dRatio"]["ratio"] || "-" %></td>
             </tr>
           <% end %>

--- a/src/instances/views/index.ecr
+++ b/src/instances/views/index.ecr
@@ -118,7 +118,7 @@
               <td><%= instance[:type] %></td>
               <td><%= instance[:stats]?.try &.["usage"]?.try &.["users"]["total"] || "-" %></td>
               <td><%= instance[:stats]?.try &.["openRegistrations"]?.try { |bool| bool.as_bool ? "✔" : "❌" } || "-" %></td>
-              <td><%= instance[:flag]? ? "#{instance[:flag]} #{instance[:region]}" : "-" %></td>
+              <td><%= instance[:country]? ? "#{instance[:country][:flag]} #{instance[:country][:name]}" : "-" %></td>
               <td><%= instance[:monitor]?.try &.["30dRatio"]["ratio"] || "-" %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
This PR rewrites the parser to account for iv-org/documentation#74.  

![monitor-74](https://user-images.githubusercontent.com/70992037/123557718-64e04000-d747-11eb-8b9f-49c3d3a0d857.png)


This PR also contains the code from #29. 