### PR TITLE
Rewrite parser for iv-org/documentation#76

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ WORKDIR /app
 COPY ./shard.yml ./shard.yml
 RUN shards install
 COPY ./src/ ./src/
-RUN crystal build ./src/instances.cr --release
+RUN crystal build ./src/instances.cr -s -p -t
 
 FROM alpine:latest
-RUN apk add --no-cache gc pcre libgcc
+RUN apk add --no-cache gc pcre libgcc yaml
 WORKDIR /app
 RUN addgroup -g 1000 -S invidious && \
     adduser -u 1000 -S invidious -G invidious
 COPY ./assets/ ./assets/
+COPY ./config.yml ./config.yml
 COPY --from=builder /app/instances .
 
 EXPOSE 3000

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,9 @@
+# Uses the system's CURL binary to do so.
+fetch_onion_instance_stats: true
+
+# TOR's Sock proxy address that CURL uses to connect to hidden services
+tor_sock_proxy_address: "127.0.0.1"
+tor_sock_proxy_port: 9050
+
+# Minutes before refreshing the instance stats
+minutes_between_refresh: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '3'
 services:
+  tor-socks-proxy:
+    container_name: tor-socks-proxy
+    image: peterdavehello/tor-socks-proxy:latest
+    ports:
+      - "127.0.0.1:8853:53/udp"
+      - "127.0.0.1:9150:9150/tcp"
+    restart: unless-stopped
+
   instances:
     build: .
     restart: unless-stopped

--- a/src/fetch.cr
+++ b/src/fetch.cr
@@ -1,0 +1,125 @@
+# Fetch a country's emoji flag from their country code (ISO 3166 alpha-2).
+#
+# A flag is made out of two regional indicator symbols.
+# So in order to convert from an ISO 3166 alpha-2 code into unicode we'll have to
+# add a specific offset to each character to make them into the required regional
+# indicator symbols. This offset is exactly 0x1f1a5.
+#
+# Reference implementation https://schinckel.net/2015/10/29/unicode-flags-in-python/
+private def fetch_flag(country_code)
+  return country_code.codepoints.map { |codepoint| (codepoint + 0x1f1a5).chr }.join("")
+end
+
+# Extracts the nested modified information containing source url and changes.
+private def extract_modified_information(modified_hash)
+  if modified = modified_hash.as_h?
+    return Modified.new(
+      source: modified["source"].as_s,
+      changes: modified["changes"].as_s
+    )
+  end
+end
+
+# Extracts information common to all instance types.
+private def extract_prerequisites(instance_data)
+  uri = URI.parse(instance_data["url"].to_s)
+  host = uri.host
+
+  # Fetch country data
+  region = instance_data["country"].to_s
+  flag = fetch_flag(region)
+
+  privacy_policy = instance_data["privacy_policy"].as_s?
+  owner = {name: instance_data["owner"].to_s.split("/")[-1].to_s, url: instance_data["owner"].as_s}
+  modified = extract_modified_information(instance_data["modified"])
+  notes = instance_data["notes"].as_a?
+
+  mirrors = [] of Mirrors
+  instance_data["mirrors"].as_a?.try &.each do |m|
+    mirrors << Mirrors.new(
+      url: m["url"].as_s,
+      region: m["country"].as_s,
+      flag: fetch_flag(m["country"].as_s)
+    )
+  end
+
+  return uri, host, region, flag, privacy_policy, owner, modified, notes, mirrors
+end
+
+def prepare_http_instance(instance_data, instances_storage, monitors)
+  uri, host, region, flag, privacy_policy, owner, modified, notes, mirrors = extract_prerequisites(instance_data)
+
+  # Fetch status information
+  if status = instance_data["status"].as_h?
+    status_url = status["url"].as_s
+  else
+    status_url = nil
+  end
+
+  ddos_mitm_protection = instance_data["ddos_mitm_protection"].as_s?
+
+  client = HTTP::Client.new(uri)
+  client.connect_timeout = 5.seconds
+  client.read_timeout = 5.seconds
+
+  begin
+    stats = JSON.parse(client.get("/api/v1/stats").body)
+  rescue ex
+    stats = nil
+  end
+
+  monitor = monitors.try &.select { |monitor| monitor["name"].try &.as_s == host }[0]?
+  return {
+    region:               region,
+    flag:                 flag,
+    stats:                stats,
+    type:                 "https",
+    uri:                  uri.to_s,
+    status_url:           status_url,
+    privacy_policy:       privacy_policy,
+    ddos_mitm_protection: ddos_mitm_protection,
+    owner:                owner,
+    modified:             modified,
+    mirrors:              mirrors,
+    notes:                notes,
+    monitor:              monitor || instances_storage[host]?.try &.[:monitor]?,
+  }
+end
+
+def prepare_onion_instance(instance_data, instances_storage)
+  uri, host, region, flag, privacy_policy, owner, modified, notes, mirrors = extract_prerequisites(instance_data)
+
+  associated_clearnet_instance = instance_data["associated_clearnet_instance"].as_s?
+
+  if CONFIG["fetch_onion_instance_stats"]?
+    begin
+      args = Process.parse_arguments("--socks5-hostname '#{CONFIG["tor_sock_proxy_address"]}:#{CONFIG["tor_sock_proxy_port"]}' 'http://#{uri.host}/api/v1/stats'")
+      response = nil
+      Process.run("curl", args: args) do |result|
+        data = result.output.read_line
+        response = JSON.parse(data)
+      end
+
+      stats = response
+    rescue ex
+      stats = nil
+    end
+  else
+    stats = nil
+  end
+
+  return {
+    region:                       region,
+    flag:                         flag,
+    stats:                        stats,
+    type:                         "onion",
+    uri:                          uri.to_s,
+    associated_clearnet_instance: associated_clearnet_instance,
+    privacy_policy:               privacy_policy,
+    owner:                        owner,
+    modified:                     modified,
+    mirrors:                      mirrors,
+    notes:                        notes,
+    monitor:                      nil,
+  }
+end

--- a/src/helpers/helpers.cr
+++ b/src/helpers/helpers.cr
@@ -1,7 +1,6 @@
 require "yaml"
 
-def load_config()
+def load_config
   config = YAML.parse(File.read("config.yml"))
   return config
 end
-

--- a/src/helpers/helpers.cr
+++ b/src/helpers/helpers.cr
@@ -1,0 +1,7 @@
+require "yaml"
+
+def load_config()
+  config = YAML.parse(File.read("config.yml"))
+  return config
+end
+

--- a/src/helpers/helpers.cr
+++ b/src/helpers/helpers.cr
@@ -1,6 +1,9 @@
 require "yaml"
 
 def load_config
-  config = YAML.parse(File.read("config.yml"))
-  return config
+  return YAML.parse(File.read("config.yml"))
+end
+
+def load_instance_yaml(contents)
+  return YAML.parse(contents)
 end

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -18,6 +18,10 @@ require "http/client"
 require "kemal"
 require "uri"
 
+require "./helpers/*"
+
+CONFIG = load_config()
+
 Kemal::CLI.new ARGV
 
 macro rendered(filename)
@@ -68,6 +72,23 @@ spawn do
 
       case type = host.split(".")[-1]
       when "onion"
+        type = "onion"
+
+        if CONFIG["fetch_onion_instance_stats"]?
+          begin
+            args = Process.parse_arguments("--socks5-hostname '#{CONFIG["tor_sock_proxy_address"]}:#{CONFIG["tor_sock_proxy_port"]}' 'http://#{uri.host}/api/v1/stats'")
+            response = nil
+            Process.run("curl", args: args) do |result|
+              data = result.output.read_line
+              response = JSON.parse(data)
+            end
+
+            stats = response
+
+          rescue ex
+            stats = nil
+          end
+        end
       when "i2p"
       else
         type = uri.scheme.not_nil!
@@ -88,7 +109,7 @@ spawn do
     INSTANCES.clear
     INSTANCES.merge! instances
 
-    sleep 5.minutes
+    sleep CONFIG["minutes_between_refresh"].as_i.minutes
   end
 end
 

--- a/src/instances.cr
+++ b/src/instances.cr
@@ -84,7 +84,6 @@ spawn do
             end
 
             stats = response
-
           rescue ex
             stats = nil
           end

--- a/src/instances/views/index.ecr
+++ b/src/instances/views/index.ecr
@@ -118,7 +118,7 @@
               <td><%= instance[:type] %></td>
               <td><%= instance[:stats]?.try &.["usage"]?.try &.["users"]["total"] || "-" %></td>
               <td><%= instance[:stats]?.try &.["openRegistrations"]?.try { |bool| bool.as_bool ? "✔" : "❌" } || "-" %></td>
-              <td><%= instance[:flag]? ? "#{instance[:flag]} #{instance[:region]}" : "-" %></td>
+              <td><%= instance[:region]? ? "#{instance[:flag]} #{instance[:region]}" : "-" %></td>
               <td><%= instance[:monitor]?.try &.["30dRatio"]["ratio"] || "-" %></td>
             </tr>
           <% end %>


### PR DESCRIPTION
This PR rewrites the parser to account for iv-org/documentation#76.  

All new fields added by said PR has been added as well.
![NEW](https://user-images.githubusercontent.com/70992037/129465596-436afe35-562f-40e7-a6f4-81db81902943.png)



This PR also contains the code from #29. 